### PR TITLE
fix: add KEY_NOT_FOUND case to redis.Get()

### DIFF
--- a/redis/read.go
+++ b/redis/read.go
@@ -12,6 +12,9 @@ func (r Client) Get(ctx context.Context, key string) (string, error) {
 		r.log.Error("REDIS_GET", err)
 		return val, err
 	}
+	if err == redis.Nil {
+		return val, fmt.Errorf("KEY_NOT_FOUND")
+	}
 	return val, nil
 }
 


### PR DESCRIPTION
Fixes an issue where the client.Get() function has a logic error and it does not distinguish between the following two cases:
- key exists but has no value
- key does not exist

The function now returns an error if no key is found in the db.