### PR TITLE
fix/logging-bug

### DIFF
--- a/http/server/README.md
+++ b/http/server/README.md
@@ -9,6 +9,27 @@
                 })
         })
 
+        // Change logger to log different levels.
+	// Available levels: "empty", "erroronly", "Standard"
+	rtr.SetLogger("erroronly")
+
+	// Changes logger to log requests or not
+	rtr.SetLogRequest(true)
+
+	// Add a catchall middleware to log requests and handle errors
+	// This is optional, but recommended
+	// SetLogRequest and SetLogger must be called before this for the correct behaviour
+	rtr.AddCatchAll()
+
+	// sample custom middleware
+	rtr.Engine.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	})
+
+
+
 	// use "esc" to create a "codified" version of static files and declare like this
 	// https://github.com/mjibson/esc
 	// for example ~/go/bin/esc -o testdir/test.go -pkg static -ignore=".*.go" testdir

--- a/http/server/example/server_example.go
+++ b/http/server/example/server_example.go
@@ -3,35 +3,48 @@ package main
 import (
 	"errors"
 	"net/http"
-        "github.com/kelchy/go-lib/http/server"
+
+	"github.com/kelchy/go-lib/http/server"
 )
 
 func main() {
 	// initialize with empty cors setting
-        rtr, _ := server.New([]string{"http://localhost:8080"})
+	rtr, _ := server.New([]string{"http://localhost:8080"})
+
+	// Change logger to log different levels.
+	// Available levels: "empty", "erroronly", "Standard"
+	rtr.SetLogger("erroronly")
+
+	// Changes logger to log requests or not
+	rtr.SetLogRequest(true)
+
+	// Add a catchall middleware to log requests and handle errors
+	// This is optional, but recommended
+	// SetLogRequest and SetLogger must be called before this for the correct behaviour
+	rtr.AddCatchAll()
 
 	// sample custom middleware
-        rtr.Engine.Use(func (next http.Handler) http.Handler {
-                return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                        next.ServeHTTP(w, r)
-                })
-        })
+	rtr.Engine.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	})
 
 	// use "esc" to create a "codified" version of static files and declare like this
 	// https://github.com/mjibson/esc
 	// for example ~/go/bin/esc -o testdir/test.go -pkg static -ignore=".*.go" testdir
-        //rtr.StaticFs("/test/", static.FS(false))
+	//rtr.StaticFs("/test/", static.FS(false))
 
 	// api definition
-        rtr.Get("/welcome", func(w http.ResponseWriter, r *http.Request) {
-                server.JSON(w, r, map[string]string{
-                        "status": "success",
-                })
-        })
-        rtr.Get("/crash", func(w http.ResponseWriter, r *http.Request) {
+	rtr.Get("/welcome", func(w http.ResponseWriter, r *http.Request) {
+		server.JSON(w, r, map[string]string{
+			"status": "success",
+		})
+	})
+	rtr.Get("/crash", func(w http.ResponseWriter, r *http.Request) {
 		panic(errors.New("deliberate crash"))
-        })
+	})
 
-	// run server with cleartext http/2
-        rtr.Run("http", ":8080")
+	// run server with http
+	rtr.Run("http", ":8080")
 }

--- a/http/server/go.mod
+++ b/http/server/go.mod
@@ -1,4 +1,4 @@
-//v0.0.2
+//v0.0.3
 module github.com/kelchy/go-lib/http/server
 
 require (

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -1,22 +1,22 @@
 package server
 
 import (
+	"errors"
+	"net/http"
+
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/go-chi/cors"
-	"errors"
-	"net/http"
+	"github.com/kelchy/go-lib/log"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
-	"github.com/kelchy/go-lib/log"
 )
-
 
 // Router - initialized instance
 type Router struct {
-	Engine		*chi.Mux
-	log		log.Log
-	logRequest	bool
+	Engine     *chi.Mux
+	log        log.Log
+	logRequest bool
 }
 
 // New - constructor function to initialize instance
@@ -30,20 +30,23 @@ func New(origins []string) (Router, error) {
 	rtr.logRequest = true
 
 	if len(origins) == 0 {
-		origins = []string{ "http://localhost", "https://localhost" }
+		origins = []string{"http://localhost", "https://localhost"}
 	}
 	rtr.Engine = chi.NewRouter()
 	rtr.Engine.Use(cors.Handler(cors.Options{
-		AllowedOrigins: origins,
-		AllowedMethods: []string{ "GET", "POST", "PUT", "DELETE" },
-		AllowedHeaders: []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
-		ExposedHeaders: []string{"Link"},
+		AllowedOrigins:   origins,
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
+		ExposedHeaders:   []string{"Link"},
 		AllowCredentials: true,
-		MaxAge: 12 * 60 * 60,
+		MaxAge:           12 * 60 * 60,
 	}))
 	rtr.Engine.Use(middleware.RealIP)
-	rtr.Engine.Use(rtr.catchall)
 	return rtr, nil
+}
+
+func (rtr *Router) AddCatchAll() {
+	rtr.Engine.Use(rtr.catchall)
 }
 
 // SetLogger - changes the logger mode
@@ -61,7 +64,7 @@ func (rtr *Router) SetLogRequest(lr bool) {
 
 // Run - run and listen for http
 func (rtr Router) Run(proto string, hostport string) error {
-	rtr.log.Out("SERVER_RUN", "Listening " + proto + " " + hostport)
+	rtr.log.Out("SERVER_RUN", "Listening "+proto+" "+hostport)
 	var e error
 	if proto == "http" {
 		e = http.ListenAndServe(hostport, rtr.Engine)
@@ -80,7 +83,7 @@ func (rtr Router) Run(proto string, hostport string) error {
 
 // RunS - run and listen for https
 func (rtr Router) RunS(proto string, hostport string, crt string, key string) error {
-	rtr.log.Out("SERVER_RUNS", "Listening " + proto + " " + hostport)
+	rtr.log.Out("SERVER_RUNS", "Listening "+proto+" "+hostport)
 	var e error
 	if proto == "https" {
 		e = http.ListenAndServeTLS(hostport, crt, key, rtr.Engine)
@@ -98,22 +101,22 @@ func (rtr Router) RunS(proto string, hostport string, crt string, key string) er
 // Static - function to handle and serve static files within a directory on live system
 func (rtr Router) Static(urlPath string, dirPath string) {
 	// do not use wildcard (*) in urlPath
-	rtr.Engine.Handle(urlPath + "*", http.StripPrefix(urlPath, http.FileServer(http.Dir(dirPath))))
+	rtr.Engine.Handle(urlPath+"*", http.StripPrefix(urlPath, http.FileServer(http.Dir(dirPath))))
 	// TODO: handle wildcards better
 }
 
 // StaticFs - function to handle and serve static files embedded into binary using esc
 func (rtr Router) StaticFs(urlPath string, fs http.FileSystem) {
 	/*
-	generate a boxed static filesystem by using esc (https://github.com/mjibson/esc):
-		~/go/bin/esc -o static/static.go -pkg static -ignore=".*.go" ./static
-	on your project's home dir, use it like this:
-		var rtr server.Router
-		rtr.New([]string{})
-		rtr.StaticFs("/static/", static.FS(false))
-	static.FS() returns a standard http.FileSystem which you can pass to this function
+		generate a boxed static filesystem by using esc (https://github.com/mjibson/esc):
+			~/go/bin/esc -o static/static.go -pkg static -ignore=".*.go" ./static
+		on your project's home dir, use it like this:
+			var rtr server.Router
+			rtr.New([]string{})
+			rtr.StaticFs("/static/", static.FS(false))
+		static.FS() returns a standard http.FileSystem which you can pass to this function
 	*/
 	// do not use wildcard (*) in urlPath
-	rtr.Engine.Handle(urlPath + "*", http.FileServer(fs))
+	rtr.Engine.Handle(urlPath+"*", http.FileServer(fs))
 	// TODO: handle wildcards better
 }


### PR DESCRIPTION
**Fixed bug with SetLogRequest and SetLogger functionality.**
- Bug Description
SetLogRequest and SetLogger functionality do not work because New() already makes a call to the catchall() function on init which returns a http handler based on the initial value of the log and logRequest. This http handler is attached to the middleware and future calls to the SetLogRequest( ) and SetLogger( ) do not affect the instance of that http handler so they do not work.

- Solution
Separated the attaching of the catchAll middleware from New( ). Users now have to attach the middleware themselves. To make changes to the logs, they need to call SetLogRequest / SetLogger before attaching the catchAll middleware which will be based on the logger params at that point in time.