### PR TITLE
[redis] implement redis TTL for given a key

### DIFF
--- a/redis/go.mod
+++ b/redis/go.mod
@@ -1,4 +1,4 @@
-//v0.0.8
+//v0.0.9
 module github.com/kelchy/go-lib/redis
 
 require (

--- a/redis/read.go
+++ b/redis/read.go
@@ -39,7 +39,7 @@ func (r Client) Keys(ctx context.Context, match string) ([]string, error) {
 }
 
 // TTL - implementation of redis TTL, ctx can be nil
-// - returns in time.Duration which is always the nanoseconds, so we accept a params to convert in library
+// - returns in time.Duration which is always in nanoseconds, so we accept a params to convert in library
 func (r Client) TTL(ctx context.Context, key string, precision string) (time.Duration, error) {
 	val, err := r.Client.TTL(ctx, key).Result()
 	if err != nil && err != redis.Nil {

--- a/redis/read.go
+++ b/redis/read.go
@@ -42,9 +42,10 @@ func (r Client) Keys(ctx context.Context, match string) ([]string, error) {
 // -- returns in time.Duration which is always in nanoseconds; convert to seconds
 // -- it returns -1 (-1ns) when there is no associated expiry
 // -- it returns -2 (-2ns) when there is no key
-func (r Client) TTL(ctx context.Context, key string) (time.Duration, error) {
+func (r Client) TTL(ctx context.Context, key string) (int64, error) {
 	val, err := r.Client.TTL(ctx, key).Result()
 
+	// return a negative number to not confuse it with a positive value response
 	if err != nil {
 		r.log.Error("REDIS_TTL", err)
 		return -3, err
@@ -62,5 +63,5 @@ func (r Client) TTL(ctx context.Context, key string) (time.Duration, error) {
 		return -1, errMsg
 	}
 
-	return val / time.Second, nil
+	return int64(val / time.Second), nil
 }


### PR DESCRIPTION
- implement [redis TTL method](https://github.com/redis/go-redis/blob/cae67723092cac2cb441bc87044ab9edacb2484d/commands.go#L753)
- redis [TTL value returns](http://redis.io/commands/ttl)
- since time.Duration [always returns in nanoseconds](https://pkg.go.dev/time#Duration), we do the conversion in the library

- example of the implementation code:
```
key := fmt.Sprintf(string(constants.DataUsageCache) + userID)
	value, getErr := database.RedisGetTTL(key, precision)
```