### PR TITLE
[mongo] feat: implement mongo BulkWrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ env
 pkg
 bin
 
-# ignore more stuff
+# ignore more files that are usually related to a developer's system info
+# .DS_Store - macOS folder information; .idea - IntelliJ (jetbrains IDEs) settings
 .DS_Store
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 env
 pkg
 bin
+
+# ignore more stuff
+.DS_Store
+.idea

--- a/mongo/go.mod
+++ b/mongo/go.mod
@@ -1,4 +1,4 @@
-//v0.0.5
+//v0.0.6
 module github.com/kelchy/go-lib/mongo
 
 require (

--- a/mongo/write.go
+++ b/mongo/write.go
@@ -94,7 +94,8 @@ func (client Client) UpdateMany(ctx context.Context, colname string, filter inte
 }
 
 // UpdateOne - function to update a single doc in the collection, ctx can be nil
-func (client Client) UpdateOne(ctx context.Context, colname string, filter interface{}, update interface{}, opts *options.UpdateOptions) (int64, error) {
+func (client Client) UpdateOne(ctx context.Context, colname string,
+	filter interface{}, update interface{}, opts *options.UpdateOptions) (int64, error) {
 	// select collection
 	col := client.Db.Collection(colname)
 

--- a/mongo/write.go
+++ b/mongo/write.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -93,13 +94,12 @@ func (client Client) UpdateMany(ctx context.Context, colname string, filter inte
 }
 
 // UpdateOne - function to update a single doc in the collection, ctx can be nil
-func (client Client) UpdateOne(ctx context.Context, colname string,
-	filter interface{}, update interface{}, opts *options.UpdateOptions) (int64, error) {
+func (client Client) UpdateOne(ctx context.Context, colname string, filter interface{}, update interface{}, opts ...*options.UpdateOptions) (int64, error) {
 	// select collection
 	col := client.Db.Collection(colname)
 
 	// update
-	result, e := col.UpdateOne(ctx, filter, update, opts)
+	result, e := col.UpdateOne(ctx, filter, update, opts...)
 	if e != nil {
 		client.log.Error("MONGO_UPDATEONE", e)
 		return 0, e
@@ -148,4 +148,20 @@ func (client Client) ReplaceOne(ctx context.Context, colname string,
 		return 0, e
 	}
 	return result.ModifiedCount, e
+}
+
+// BulkWrite - function to write on multiple documents
+// ctx can be nil, opts is operations to execute on the collection
+func (client Client) BulkWrite(ctx context.Context, collname string, models []mongo.WriteModel, opts ...*options.BulkWriteOptions) (mongo.BulkWriteResult, error) {
+
+	// select the collection
+	coll := client.Db.Collection(collname)
+
+	result, err := coll.BulkWrite(ctx, models, opts...)
+	if err != nil {
+		client.log.Error("MONGO_BULKWRITE", err)
+		return mongo.BulkWriteResult{}, err // return nil struct for err
+	}
+
+	return *result, nil
 }

--- a/mongo/write.go
+++ b/mongo/write.go
@@ -152,7 +152,7 @@ func (client Client) ReplaceOne(ctx context.Context, colname string,
 }
 
 // BulkWrite - function to write on multiple documents
-// ctx can be nil, opts is operations to execute on the collection
+// ctx can be nil, models are an array of operations to execute on the collection, opts is optional (allow to be not provided without breaking function in Go)
 func (client Client) BulkWrite(ctx context.Context, collname string, models []mongo.WriteModel, opts ...*options.BulkWriteOptions) (mongo.BulkWriteResult, error) {
 
 	// select the collection
@@ -161,7 +161,8 @@ func (client Client) BulkWrite(ctx context.Context, collname string, models []mo
 	result, err := coll.BulkWrite(ctx, models, opts...)
 	if err != nil {
 		client.log.Error("MONGO_BULKWRITE", err)
-		return mongo.BulkWriteResult{}, err // return nil struct for err
+		return mongo.BulkWriteResult{}, err
+		// we dont return an int as operations performed information is useful (i.e. modified count, upsert count, etc, upserted IDs)
 	}
 
 	return *result, nil

--- a/mongo/write.go
+++ b/mongo/write.go
@@ -94,12 +94,12 @@ func (client Client) UpdateMany(ctx context.Context, colname string, filter inte
 }
 
 // UpdateOne - function to update a single doc in the collection, ctx can be nil
-func (client Client) UpdateOne(ctx context.Context, colname string, filter interface{}, update interface{}, opts ...*options.UpdateOptions) (int64, error) {
+func (client Client) UpdateOne(ctx context.Context, colname string, filter interface{}, update interface{}, opts *options.UpdateOptions) (int64, error) {
 	// select collection
 	col := client.Db.Collection(colname)
 
 	// update
-	result, e := col.UpdateOne(ctx, filter, update, opts...)
+	result, e := col.UpdateOne(ctx, filter, update, opts)
 	if e != nil {
 		client.log.Error("MONGO_UPDATEONE", e)
 		return 0, e


### PR DESCRIPTION
- implement mongo BulkWrite
- this is to support upsert operations on multiple documents
- sample implementation, where we want to update a document specific keys if it exists, otherwise insert

```
	var operations []mongo.WriteModel
	for _, oneBuddy := range travelBuddies {
		// filter array
		filter := bson.D{{Key: "$and", Value: bson.A{
			bson.D{{Key: "title", Value: oneBuddy.Title}},
			bson.D{{Key: "first_name", Value: oneBuddy.FirstName}},
			bson.D{{Key: "last_name", Value: oneBuddy.LastName}},
			bson.D{{Key: "userId", Value: userID}},
			bson.D{{Key: "deletedAt", Value: bson.D{{Key: "$exists", Value: false}}}}, // check if it has been soft-deleted before, if yes, we also add
		}}}

		// update to perform
		update := bson.D{
			{Key: "$inc", Value: bson.D{{Key: "count", Value: 1}}},
			{Key: "$set", Value: bson.D{
				{Key: "updatedAt", Value: time.Now()},
				{Key: "updatedBy", Value: email},
			}},
			{Key: "$setOnInsert", Value: bson.D{
				// note to self: mongo userID automatically created when setOnInsert
				// define the stuff to add here when inserting
				{Key: "createdAt", Value: time.Now()},
				{Key: "createdBy", Value: email},
			}},
		}

		// specify upsert is true
		operation := mongo.NewUpdateOneModel().SetFilter(filter).SetUpdate(update).SetUpsert(true)

		// append operation to the list of operations that we want to perform
		operations = append(operations, operation)
	}

	res, resErr := database.Mongo.BulkWrite(context.TODO(), "faberTravelBuddies", operations)
	if resErr != nil {
		log.Error("ERR_UPSERT_TRAVEL_BUDDIES", fmt.Errorf("error: %s", resErr.Error()))
		return res, resErr
	}
```

tested code with logs
```
this is the res:{InsertedCount:0 MatchedCount:2 ModifiedCount:2 DeletedCount:0 UpsertedCount:1 UpsertedIDs:map[2:ObjectID("6411e50fe5a85be49e7807c0")]}{"ts":"2023-03-15T23:32:31.114291+08:00","scope":"OK_BACKFILL_TRAVEL_BUDDIES-MAKE_BUDDIES 63fc27c93fa52a7577827edf","msg":"buddies {InsertedCount:0 MatchedCount:2 ModifiedCount:2 DeletedCount:0 UpsertedCount:1 UpsertedIDs:map[2:ObjectID(\"6411e50fe5a85be49e7807c0\")]}"}
```