### PR TITLE
fix: function names

### DIFF
--- a/log/example/log_example.go
+++ b/log/example/log_example.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	log, err := Log.New("standard")	// or empty string
+	log, err := Log.New("standard") // or empty string
 	if err != nil {
 		panic(err)
 	}
@@ -29,9 +29,9 @@ func main() {
 
 	logger, _ := Log.NewExtended("standard")
 	contextData := Log.ContextData{TraceID: "trace123", UserID: "external456", Tenant: "tenantABC"}
-	logger.InfoLog("scope", contextData, "some data", "a message")
-	logger.ErrorLog("scope", contextData, errors.New("an error occurred"), "some data", "a message")
-	logger.SuccessLog("scope", contextData, "some data", "a message")
-	logger.DebugLog("scope", contextData, "some data", "a message")
+	logger.Info("scope", contextData, "some data", "a message")
+	logger.Error("scope", contextData, errors.New("an error occurred"), "some data", "a message")
+	logger.Success("scope", contextData, "some data", "a message")
+	logger.Debug("scope", contextData, "some data", "a message")
 
 }

--- a/log/example/log_example.go
+++ b/log/example/log_example.go
@@ -31,7 +31,7 @@ func main() {
 	contextData := Log.ContextData{TraceID: "trace123", UserID: "external456", Tenant: "tenantABC"}
 	logger.Info("scope", contextData, "some data", "a message")
 	logger.Error("scope", contextData, errors.New("an error occurred"), "some data", "a message")
-	logger.Success("scope", contextData, "some data", "a message")
+	logger.Out("scope", contextData, "some data", "a message")
 	logger.Debug("scope", contextData, "some data", "a message")
 
 }

--- a/log/go.mod
+++ b/log/go.mod
@@ -1,4 +1,4 @@
-//v0.1.2
+//v0.1.3
 module github.com/kelchy/go-lib/log
 
 go 1.18

--- a/log/logger.go
+++ b/log/logger.go
@@ -39,8 +39,8 @@ func (l ExtendedLog) Info(scope string, ctx ContextData, data interface{}, messa
 	l.Log.Out(fmt.Sprintf("info:%s", scope), GetLogMessage(ctx.TraceID, ctx.Tenant, ctx.UserID, data, message))
 }
 
-// Success logs a success message
-func (l ExtendedLog) Success(scope string, ctx ContextData, data interface{}, message string) {
+// Out logs a success/ok message
+func (l ExtendedLog) Out(scope string, ctx ContextData, data interface{}, message string) {
 	l.Log.Out(fmt.Sprintf("ok:%s", scope), GetLogMessage(ctx.TraceID, ctx.Tenant, ctx.UserID, data, message))
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -12,8 +12,8 @@ type ExtendedLog struct {
 // ContextData is a struct that holds the logging context data
 type ContextData struct {
 	TraceID string
-	Tenant string
-	UserID string
+	Tenant  string
+	UserID  string
 }
 
 // NewExtended creates a new ExtendedLog struct
@@ -29,22 +29,22 @@ func NewExtended(logtype string) (ExtendedLog, error) {
 	return l, e
 }
 
-// ErrorLog logs an error message
-func (l ExtendedLog) ErrorLog(scope string, ctx ContextData, errorMsg error, data interface{}, message string) {
-	l.Error(fmt.Sprintf("error:%s", scope), GetErrorLogMessage(ctx.TraceID, ctx.Tenant, ctx.UserID, errorMsg, data, message))
+// Error logs an error message
+func (l ExtendedLog) Error(scope string, ctx ContextData, errorMsg error, data interface{}, message string) {
+	l.Log.Error(fmt.Sprintf("error:%s", scope), GetErrorLogMessage(ctx.TraceID, ctx.Tenant, ctx.UserID, errorMsg, data, message))
 }
 
-// InfoLog logs an info message
-func (l ExtendedLog) InfoLog(scope string, ctx ContextData, data interface{}, message string) {
-	l.Out(fmt.Sprintf("info:%s", scope), GetLogMessage(ctx.TraceID, ctx.Tenant, ctx.UserID, data, message))
+// Info logs an info message
+func (l ExtendedLog) Info(scope string, ctx ContextData, data interface{}, message string) {
+	l.Log.Out(fmt.Sprintf("info:%s", scope), GetLogMessage(ctx.TraceID, ctx.Tenant, ctx.UserID, data, message))
 }
 
-// SuccessLog logs a success message
-func (l ExtendedLog) SuccessLog(scope string, ctx ContextData, data interface{}, message string) {
-	l.Out(fmt.Sprintf("ok:%s", scope), GetLogMessage(ctx.TraceID, ctx.Tenant, ctx.UserID, data, message))
+// Success logs a success message
+func (l ExtendedLog) Success(scope string, ctx ContextData, data interface{}, message string) {
+	l.Log.Out(fmt.Sprintf("ok:%s", scope), GetLogMessage(ctx.TraceID, ctx.Tenant, ctx.UserID, data, message))
 }
 
-// DebugLog logs a debug message
-func (l ExtendedLog) DebugLog(scope string, ctx ContextData, data interface{}, message string) {
-	l.Debug(fmt.Sprintf("debug:%s", scope), GetLogMessage(ctx.TraceID, ctx.Tenant, ctx.UserID, data, message))
+// Debug logs a debug message
+func (l ExtendedLog) Debug(scope string, ctx ContextData, data interface{}, message string) {
+	l.Log.Debug(fmt.Sprintf("debug:%s", scope), GetLogMessage(ctx.TraceID, ctx.Tenant, ctx.UserID, data, message))
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
 )
 
 func TestErrorLog(t *testing.T) {
@@ -66,7 +65,7 @@ func TestErrorLog(t *testing.T) {
 			}()
 
 			log, _ := NewExtended("standard")
-			log.ErrorLog(tt.scope, tt.contextData, tt.errorMsg, tt.data, tt.message)
+			log.Error(tt.scope, tt.contextData, tt.errorMsg, tt.data, tt.message)
 
 			_ = w.Close()
 			<-done
@@ -134,7 +133,7 @@ func TestInfoLog(t *testing.T) {
 			}()
 
 			log, _ := NewExtended("standard")
-			log.InfoLog(tt.scope, tt.contextData, tt.data, tt.message)
+			log.Info(tt.scope, tt.contextData, tt.data, tt.message)
 
 			_ = w.Close()
 			os.Stdout = oldStdout
@@ -203,7 +202,7 @@ func TestSuccessLog(t *testing.T) {
 			}()
 
 			log, _ := NewExtended("standard")
-			log.SuccessLog(tt.scope, tt.contextData, tt.data, tt.message)
+			log.Success(tt.scope, tt.contextData, tt.data, tt.message)
 
 			_ = w.Close()
 			os.Stdout = oldStdout
@@ -272,7 +271,7 @@ func TestDebugLog(t *testing.T) {
 			}()
 
 			log, _ := NewExtended("standard")
-			log.DebugLog(tt.scope, tt.contextData, tt.data, tt.message)
+			log.Debug(tt.scope, tt.contextData, tt.data, tt.message)
 
 			_ = w.Close()
 			os.Stdout = oldStdout

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -148,7 +148,7 @@ func TestInfoLog(t *testing.T) {
 
 }
 
-func TestSuccessLog(t *testing.T) {
+func TestOutLog(t *testing.T) {
 	tests := []struct {
 		scope       string
 		traceID     string
@@ -202,7 +202,7 @@ func TestSuccessLog(t *testing.T) {
 			}()
 
 			log, _ := NewExtended("standard")
-			log.Success(tt.scope, tt.contextData, tt.data, tt.message)
+			log.Out(tt.scope, tt.contextData, tt.data, tt.message)
 
 			_ = w.Close()
 			os.Stdout = oldStdout


### PR DESCRIPTION
breaking change - updated function names for the extended logs to remove `Log` suffix from the names